### PR TITLE
added dedicated support page

### DIFF
--- a/docs/Support.md
+++ b/docs/Support.md
@@ -1,0 +1,55 @@
+# Getting Help with Doppl
+
+Our objective is to make Doppl easy to try out. The more complicated your app,
+the more likely it is that you will have questions about how to work with Doppl
+and get the best results.
+
+## Keeping Up with Updates
+
+The biggest thing is to make sure that you are up to date with the latest
+Doppl, including the Gradle plugin version and the runtime version.
+
+You can follow [@doppllib on Twitter](https://twitter.com/doppllib) or
+[subscribe to a low-frequency mailing list](http://eepurl.com/b9Kzez)
+to be notified when updates are available.
+
+There is also [a Medium blog](https://medium.com/doppl) that you can subscribe
+to in order to learn about major events in the world of Doppl.
+
+## Complex Questions: Stack Overflow
+
+If you run into problems using Doppl, the first place to turn is
+[the `doppl` Stack Overflow tag](https://stackoverflow.com/questions/tagged/doppl)
+and see if your question has already been asked and has an answer.
+
+If your question is not there, ask it! Please follow
+Stack Overflow's site rules for
+[what are good questions](https://stackoverflow.com/help/on-topic) and
+[what questions are... less good](https://stackoverflow.com/help/dont-ask)
+for their site.
+
+## Interactive Questions: Slack
+
+You may come up with questions that:
+
+- Do not fit Stack Overflow's site rules, or
+- Require more back-and-forth with Doppl developers
+
+For those, you can
+[request to join the Doppl Slack group](http://doppl.co/slackinvite.html). In
+particular, the `#newbiehelp` channel is a good place to ask basic Doppl questions.
+
+## Filing Issues
+
+If you are encountering problems with Doppl, please use some of the above
+options for getting assistance. If there, the conclusion is that you have
+encountered a bug in Doppl, you can file an issue on one of the GitHub repositories:
+
+- [`doppl-gradle`](https://github.com/doppllib/doppl-gradle) for the Gradle plugin
+- [`core-doppl`](https://github.com/doppllib/core-doppl) for the Android SDK subset supported by Doppl
+- [`j2objc`](https://github.com/doppllib/j2objc) for Doppl's fork of Google's Java-to-Objective-C translator
+
+If you have ideas for improvements to Doppl, feel free to file feature requests
+via the issue tracker at those repositories. If you are not certain which repository
+is the correct one to use, join the Slack group and ask on the `#feedback` or
+`#general` channels.


### PR DESCRIPTION
Here is a more detailed support page.

I took the liberty of setting up the Stack Overflow `doppl` tag. I recommend that you monitor it regularly, by:

- Visiting https://stackoverflow.com/questions/tagged/doppl
- Subscribing to the RSS feed (https://stackoverflow.com/feeds/tag?tagnames=doppl&sort=newest)
- Subscribing to that tag via email
- Setting up a slackbot? (https://github.com/dunglas/stack2slack)
