### PR TITLE
removed RC1 reference

### DIFF
--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -14,12 +14,11 @@ share much of the rest of your application logic between the two platforms
 ## Getting Your Feet Wet
 
 - [PartyClicker Tutorial](./Tutorial)
-- TBD pointer to from-scratch tutorial
-- TBD pointer to FAQ
+- Adding Doppl to an Existing Android Project &mdash; <i>coming soon!</i>
+- Frequently-Asked Questions &mdash; <i>coming soon!</i>
+- [Getting Help with Doppl](./Support)
 
 ## Diving Into Doppl
 
 - [Doppl Scope](./Scope)
-- TBD pointer to Android API whitelist
-- TBD pointer to known-good libraries
-- [Support](./Support)
+- Doppl-Ready Libraries &mdash; <i>coming soon!</i>

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -56,7 +56,7 @@ successfully from the command line.
 
 Doppl does not require Android Studio. However, you are welcome to use it
 as well. These instructions work with Android Studio 2.3.3 and Android Studio
-3.0 RC1.
+3.0.
 
 ### iOS
 


### PR DESCRIPTION
I had the tutorial reference Android Studio 3.0 RC1; now that Android Studio 3.0 is final, I removed that reference.